### PR TITLE
Fix doc internal link to scene-limits

### DIFF
--- a/docs/assets/sprites.md
+++ b/docs/assets/sprites.md
@@ -8,7 +8,7 @@ import { Swatch } from '@site/src/components/Swatch';
 
 Sprites are the graphics used by playable or interactive characters in your scenes. Add sprites to your game by including `.png` files in your project's `assets/sprites` folder.
 
-Because there are limits to how many sprites tiles can be loaded into a single scene, be sure to check your the frame limits across your scenes when adding new sprites. See [Scene Limits](docs/project-editor/scenes.md#scene-limits) for more information.
+Because there are limits to how many sprites tiles can be loaded into a single scene, be sure to check your the frame limits across your scenes when adding new sprites. See [Scene Limits](/docs/project-editor/scenes/#scene-limits) for more information.
 
 ## Simple Sprites
 


### PR DESCRIPTION
When creating a new locale and building we get the following warning and errors :

> [WARNING] Docs markdown link couldn't be resolved: (docs/project-editor/scenes.md) in "D:\Projects\gb-studio-docs\i18n\fr\docusaurus-plugin-content-docs\current\assets\sprites.md" for version current
> 
> [ERROR] Unable to build website for locale fr.
> [ERROR] Error: Docusaurus found broken links!

Removing the .md extension resolve this issue
Also I added slash at the begining and at the end to be consistant with other links in the documentation