### PR TITLE
Update engine-eject.md (extending-gbstudio PL Docs)

### DIFF
--- a/i18n/pl/docusaurus-plugin-content-docs/current/extending-gbstudio/engine-eject.md
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/extending-gbstudio/engine-eject.md
@@ -2,23 +2,23 @@
 sidebar_position: 8
 ---
 
-# Engine Eject
+# Wysunięcie silnika
 
-Engine Eject copies the [GBVM game engine](https://github.com/chrismaltby/gbvm) that GB Studio uses into a folder in your project, named `assets/engine`. You can edit these source files to your liking using an IDE to have more control over how your GB Studio game is built. This feature is only recomended for developers familiar with GBDK.
+Wysunięcie silnika kopiuje [silnik gry GBVM](https://github.com/chrismaltby/gbvm), który używa GB Studio, do folderu w twoim projekcie o nazwie `assets/engine`. Możesz edytować te pliki źródłowe według własnego uznania, używając IDE, aby mieć większą kontrolę nad tym, jak tworzona jest twoja gra w GB Studio. Ta funkcja jest zalecana tylko dla programistów zaznajomionych z GBDK.
 
-To use Engine Eject, click on _Game_ at the top of the GB Studio window and navigate to the _Advanced_ tab to show the _Engine Eject_ button.
+Aby użyć wysunięcia silnika, kliknij na manu _Gra_ w menu programu GB Srudio i przejdź do _Zaawansowane_, aby wyświetlić opcję _Wysuń silnik_.
 
-After clicking _Eject_ your project will gain a new folder named `/engine ` with the subfolders `/include` and `/src`.
+Po kliknięciu _Wysuń_ twój projekt zyska nowy folder o nazwie `/engine` z podfolderami `/include` i `/src`.
 
-## Reverting Files
+## Przywracanie plików
 
-To revert any GBDK file back to its GB Studio default, delete it from the `assets/engine` folder. Deleting the whole `assets/engine` folder ensures that all GBDK code reverts back to the GB Studio defaults. You can also do this by pressing _Engine Eject_ again, which will overwrite your `assets/engine` folder with the GB Studio defaults.
+Aby przywrócić dowolne plik GBDK do domyślnego stanu GB Studio, należy usunąć go z folderu `assets/engine`. Usunięcie całego folderu `assets/engine` spowoduje przywrócenie wszystkich kodów GBDK do domyślnych ustawień GB Studio. Możesz również to zrobić, ponownie naciskając _Wysuń silnik_, co nadpisze twój folder `assets/engine` domyślnymi plikami GB Studio.
 
-## Compile Errors
+## Błędy kompilacji
 
-If you have bugged or incompatible files in the `/engine` folder, GB Studio will not be able to build your game. Error messages can be found in the _Build & Run_ window.
+Jeśli w folderze `/engine` znajdują się uszkodzone lub niekompatybilne pliki, GB Studio nie będzie w stanie zbudować twojej gry. Komunikaty o błędach można znaleźć w [Dzienniku kompilacji](/docs/debugger#build-log).
 
-The error message will often explain which files have problems and point you to the line number where the problem was found, for example this error is showing that line 77 of `src/core/actor.c` is using a variable that has not yet been defined:
+Komunikat o błędzie często wyjaśnia, które pliki mają problemy i wskazuje numer linii, w której problem został znaleziony. Na przykład ten błąd pokazuje, że linia 77 w `src/core/actor.c` używa zmiennej, która nie została jeszcze zdefiniowana:
 
 ```
 Compiling: src/core/actor.c
@@ -27,4 +27,4 @@ src/core/actor.c:77: error 22: Array or pointer required for '[]' operation
 src/core/actor.c:77: error 47: indirections to different types assignment   
 ```
 
-These errors will not be caused by missing files. GB Studio refers to its default engine in place of any missing `assets/engine` files. Fixing or removing the files that caused the error will allow your game to build and run again.
+Te błędy nie będą spowodowane brakującymi plikami. GB Studio odnosi się do swojego domyślnego silnika w miejsce wszelkich brakujących plików `assets/engine`. Naprawienie lub usunięcie plików, które spowodowały błąd, pozwoli na ponowne zbudowanie i uruchomienie gry.


### PR DESCRIPTION
Update file engine-eject from extending-gbstudio in PL Docs. 
Traslation was based on ENG Docs [25/07/2024]