### PR TITLE
Update index.md (fix typo with var "info" in getting-started PL Docs)

### DIFF
--- a/i18n/pl/docusaurus-plugin-content-docs/current/getting-started/index.md
+++ b/i18n/pl/docusaurus-plugin-content-docs/current/getting-started/index.md
@@ -8,7 +8,7 @@ Kiedy po raz pierwszy otworzysz GB Studio, zobaczysz okno _Nowy projekt_.
 
 <img title="New Project" src="/img/screenshots/new-project-v4.png" width="752" />
 
-:::Podpowiedź
+:::info
 
 Zaleca się rozpoczęcie od użycia szablonu Przykładowy Projekt, ponieważ zawiera on przykłady wielu funkcji, które oferuje GB Studio.
 


### PR DESCRIPTION
Update for the index - getting-started section in PL Docs, by mistake I had additionally translate the variable "info". 
Now should be fix and fine.
Sorry.