### PR TITLE
Update to avatar requirements

### DIFF
--- a/docs/assets/ui-elements.md
+++ b/docs/assets/ui-elements.md
@@ -41,4 +41,4 @@ Emotes are stored in `assets/emotes` and must be defined as `16px x 16px` sized 
 
 ## Avatars
 
-Avatars are stored in `assets/avatars` and must be defined as `16px x 16px` sized `.png` files following the same color requirements used for creating spritesheets. You can display an avatar in a [Display Dialogue](/docs/scripting/script-glossary/dialogue-menus#display-dialogue) event by clicking `Add Avatar` within the event.
+Avatars are stored in `assets/avatars` and must be defined as `16px x 16px` sized `.png` files following the same color requirements used for creating backgrounds. You can display an avatar in a [Display Dialogue](/docs/scripting/script-glossary/dialogue-menus#display-dialogue) event by clicking `Add Avatar` within the event.


### PR DESCRIPTION
Since avatars appear in the same layer as menus and dialogue, they have the same color requirements. They can use the dark green color #306850, but not the color #65ff00 used for transparency in sprites and emotes.