### PR TITLE
Fix homepage assets

### DIFF
--- a/src/components/HomepageFeatures/index.js
+++ b/src/components/HomepageFeatures/index.js
@@ -5,6 +5,7 @@ import Lightbox from "yet-another-react-lightbox";
 import Zoom from "yet-another-react-lightbox/plugins/zoom";
 import "yet-another-react-lightbox/styles.css";
 import useIsBrowser from "@docusaurus/useIsBrowser";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 
 const FeatureList = [
   {
@@ -84,7 +85,7 @@ function Feature({ winImg, macImg, title, description, onOpen, imgPlatform }) {
       <div className="text--center">
         {imgPlatform !== "unknown" && (
           <img
-            src={imgPlatform === "mac" ? macImg : winImg}
+            src={useBaseUrl(imgPlatform === "mac" ? macImg : winImg)}
             alt={title}
             onClick={onOpen}
           />
@@ -101,6 +102,19 @@ function Feature({ winImg, macImg, title, description, onOpen, imgPlatform }) {
 export default function HomepageFeatures() {
   const [index, setIndex] = React.useState(-1);
   const isBrowser = useIsBrowser();
+
+  const macSlides = [
+    { src: useBaseUrl("/img/home/screenshot_mac_1_v4.png") },
+    { src: useBaseUrl("/img/home/screenshot_mac_2_v4.png") },
+    { src: useBaseUrl("/img/home/screenshot_mac_3_v4.png") },
+    { src: useBaseUrl("/img/home/screenshot_mac_4_v4.png") },
+  ];
+  const winSlides = [
+    { src: useBaseUrl("/img/home/screenshot_win_1_v4.png") },
+    { src: useBaseUrl("/img/home/screenshot_win_2_v4.png") },
+    { src: useBaseUrl("/img/home/screenshot_win_3_v4.png") },
+    { src: useBaseUrl("/img/home/screenshot_win_4_v4.png") },
+  ];
 
   let imgPlatform = "unknown";
   if (isBrowser) {
@@ -135,21 +149,7 @@ export default function HomepageFeatures() {
           open={index >= 0}
           index={index}
           close={() => setIndex(-1)}
-          slides={
-            imgPlatform === "mac"
-              ? [
-                  { src: "/img/home/screenshot_mac_1_v4.png" },
-                  { src: "/img/home/screenshot_mac_2_v4.png" },
-                  { src: "/img/home/screenshot_mac_3_v4.png" },
-                  { src: "/img/home/screenshot_mac_4_v4.png" },
-                ]
-              : [
-                  { src: "/img/home/screenshot_win_1_v4.png" },
-                  { src: "/img/home/screenshot_win_2_v4.png" },
-                  { src: "/img/home/screenshot_win_3_v4.png" },
-                  { src: "/img/home/screenshot_win_4_v4.png" },
-                ]
-          }
+          slides={imgPlatform === "mac" ? macSlides : winSlides}
           plugins={[Zoom]}
         />
       )}

--- a/src/components/HomepageGBSCentral/index.js
+++ b/src/components/HomepageGBSCentral/index.js
@@ -1,6 +1,7 @@
 import React from "react";
 import clsx from "clsx";
 import styles from "./styles.module.css";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 
 export default function HomepageGBSCentral() {
   return (
@@ -16,7 +17,7 @@ export default function HomepageGBSCentral() {
               </h3>
               <a className={styles.logo} href="https://gbstudiocentral.com/">
                 <img
-                  src="/img/home/gbscentral_logo.png"
+                  src={useBaseUrl("/img/home/gbscentral_logo.png")}
                   alt="GB Studio Central"
                 />
               </a>
@@ -34,7 +35,7 @@ export default function HomepageGBSCentral() {
                 className={styles.logo}
                 href="https://www.patreon.com/gbs_central"
               >
-                <img src="/img/home/gbsmagazine.png" alt="GB Studio Magazine" />
+                <img src={useBaseUrl("/img/home/gbsmagazine.png")} alt="GB Studio Magazine" />
               </a>
               <a
                 className={styles.button}

--- a/src/components/HomepageHero/GB3D.js
+++ b/src/components/HomepageHero/GB3D.js
@@ -58,22 +58,28 @@ function Scene(props) {
   const colorMode = props.colorMode;
   const ref = useRef();
 
-  const obj = useLoader(OBJLoader, "/img/hero/logo9.obj");
-  const texture = useLoader(
-    TextureLoader,
+  const objUrl = useBaseUrl("/img/hero/logo9.obj");
+  const textureUrl = useBaseUrl(
     colorMode === "dark"
       ? "/img/hero/texture-dark.png"
       : "/img/hero/texture.png"
   );
-  const normals = useLoader(TextureLoader, "/img/hero/normals.png");
-  const roughness = useLoader(TextureLoader, "/img/hero/roughness4.png");
-  const glow = useLoader(TextureLoader, "/img/hero/glow3.png");
+  const normalsUrl = useBaseUrl("/img/hero/normals.png");
+  const roughnessUrl = useBaseUrl("/img/hero/roughness4.png");
+  const glowUrl = useBaseUrl("/img/hero/glow3.png");
+  const videoUrl = useBaseUrl("/img/hero/recording.mp4");
+
+  const obj = useLoader(OBJLoader, objUrl);
+  const texture = useLoader(TextureLoader, textureUrl);
+  const normals = useLoader(TextureLoader, normalsUrl);
+  const roughness = useLoader(TextureLoader, roughnessUrl);
+  const glow = useLoader(TextureLoader, glowUrl);
 
   texture.colorSpace = SRGBColorSpace;
 
   const [video] = useState(() => {
     const vid = document.createElement("video");
-    vid.src = "/img/hero/recording.mp4";
+    vid.src = videoUrl;
     vid.crossOrigin = "Anonymous";
     vid.loop = true;
     vid.muted = true;

--- a/src/components/HomepageHero/GB3D.js
+++ b/src/components/HomepageHero/GB3D.js
@@ -177,7 +177,7 @@ export const GB3D = ({ colorMode }) => {
       -2 + clamp01(e.touches[0].pageY / window.innerHeight) * 8,
       distance * Math.cos(angle),
     ]);
-  });
+  }, []);
 
   useEffect(() => {
     const onMouseMove = (e) => {
@@ -196,7 +196,7 @@ export const GB3D = ({ colorMode }) => {
     return () => {
       window.removeEventListener("mousemove", onMouseMove);
     };
-  });
+  }, []);
 
   const fallback = (
     <ThemedImage

--- a/src/components/HomepageItch/index.js
+++ b/src/components/HomepageItch/index.js
@@ -1,5 +1,6 @@
 import React from "react";
 import styles from "./styles.module.css";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 
 export default function HomepageItch() {
   return (
@@ -44,7 +45,7 @@ export default function HomepageItch() {
           </div>
           <div className="col col--6">
             <div className={styles.gradient}>
-              <img src="/img/home/madewith.jpg" alt="Made With GB Studio" />
+              <img src={useBaseUrl("/img/home/madewith.jpg")} alt="Made With GB Studio" />
             </div>
           </div>
         </div>


### PR DESCRIPTION
When you start a local server with a specific locale the home page is crashing because assets are not able to load.
This PR fix this issue.

As an example, try to run a server with:
`yarn start -- --locale de`

You should see the homepage with the following message:

> ERROR
Could not load /img/hero/texture.png: undefined
    at eval (webpack-internal:///./node_modules/@react-three/fiber/dist/index-ca597524.esm.js:1719:36)
    at HTMLImageElement.onImageError (webpack-internal:///./node_modules/three/src/loaders/ImageLoader.js:64:19)

Because the base url is set on the local server to this value:
`http://localhost:3001/de/`

We can fix this by using `useBaseUrl` for all the src